### PR TITLE
Optional prune bundler

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name        "opsworks-puma"
 description "Manage the ruby app server puma on AWS OpsWorks"
 maintainer  "Sport Ngin"
 license     "MIT"
-version     "0.0.4"
+version     "0.0.5"
 
 depends "nginx"
 depends "deploy"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@ node[:deploy].each do |application, deploy|
     worker_timeout deploy[:puma][:worker_timeout]
     restart_timeout deploy[:puma][:restart_timeout] || 120
     exec_prefix deploy[:puma][:exec_prefix] || "bundle exec"
-    prune_bundler deploy[:puma][:exec_prefix]
+    prune_bundler deploy[:puma][:prune_bundler]
   end
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,7 @@ node[:deploy].each do |application, deploy|
     worker_timeout deploy[:puma][:worker_timeout]
     restart_timeout deploy[:puma][:restart_timeout] || 120
     exec_prefix deploy[:puma][:exec_prefix] || "bundle exec"
+    prune_bundler deploy[:puma][:exec_prefix]
   end
 end
 


### PR DESCRIPTION
Found out that recently this is causing deploys to fail.  Allowing us to set this as default will fix our deploys, and it should be optional to begin with.