### PR TITLE
Add Nginx Prefix Directory to Attributes file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,3 @@
 default.puma[:version] = "2.8.2"
+
+default[:nginx][:prefix_dir] = "/usr/share/nginx"


### PR DESCRIPTION

Adds [:nginx][:prefix_dir] attribute for use with static pages.