### PR TITLE
Allow for Puma plugins

### DIFF
--- a/definitions/puma_config.rb
+++ b/definitions/puma_config.rb
@@ -4,7 +4,7 @@ define :puma_config, :owner => 'deploy', :group => 'nginx', :directory  => nil, 
                      :quiet => false, :thread_min => 0, :thread_max => 16, :bind => nil, :control_app_bind => nil,
                      :workers => 0, :activate_control_app => true, :logrotate => true, :exec_prefix => nil,
                      :config_source => nil, :config_cookbook => nil, :worker_timeout => nil,
-                     :preload_app => false, :prune_bundler => true, :on_worker_boot => nil do
+                     :preload_app => false, :prune_bundler => true, :on_worker_boot => nil, :plugins => nil do
 
   params[:directory] ||= "/srv/www/#{params[:name]}"
   params[:working_dir] ||= "#{params[:directory]}/current"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,6 +21,7 @@ node[:deploy].each do |application, deploy|
     exec_prefix deploy[:puma][:exec_prefix] || "bundle exec"
     prune_bundler deploy[:puma][:prune_bundler]
     plugins deploy[:puma][:plugins]
+    daemonize deploy[:puma][:daemonize]
   end
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,7 @@ node[:deploy].each do |application, deploy|
     restart_timeout deploy[:puma][:restart_timeout] || 120
     exec_prefix deploy[:puma][:exec_prefix] || "bundle exec"
     prune_bundler deploy[:puma][:prune_bundler]
+    plugins deploy[:puma][:plugins]
   end
 end
 

--- a/templates/default/puma.rb.erb
+++ b/templates/default/puma.rb.erb
@@ -5,7 +5,7 @@ directory "<%= @working_dir %>"
 
 # A list of plugins for puma to load in
 <% if @plugins %>
-  <% plugins.each do |plugin| %>
+  <% @plugins.each do |plugin| %>
 plugin '<%= plugin %>'
   <% end %>
 <% end %>

--- a/templates/default/puma.rb.erb
+++ b/templates/default/puma.rb.erb
@@ -3,6 +3,13 @@
 # The directory to operate out of.
 directory "<%= @working_dir %>"
 
+# A list of plugins for puma to load in
+<% if @plugins %>
+  <% plugins.each do |plugin| %>
+plugin '<%= plugin %>'
+  <% end %>
+<% end %>
+
 # Use a object or block as the rack application. This allows the
 # config file to be the application itself.
 #

--- a/templates/default/puma_start.sh.erb
+++ b/templates/default/puma_start.sh.erb
@@ -6,4 +6,4 @@ PATH=/usr/local/bin:$PATH
 APPNAME="<%= @name %>"
 
 echo -n "Starting $APPNAME.."
-<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %>
+<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %> & <% end %>

--- a/templates/default/puma_start.sh.erb
+++ b/templates/default/puma_start.sh.erb
@@ -6,4 +6,5 @@ PATH=/usr/local/bin:$PATH
 APPNAME="<%= @name %>"
 
 echo -n "Starting $APPNAME.."
-<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %> & <% end %>
+<% if !@daemonize; @exec_prefix = "exec #{@exec_prefix}" end %>
+<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %>&<% end %>


### PR DESCRIPTION
What
----------------------
Allow for passing in an array of plugins to enable and write those out to the puma config file.

Why
----------------------
We'd like to use puma plugins such as the metrics plugin.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

QA Plan
-------
- Use this branch to test in SE User Service with the metrics server
- [ ] Verify we can collect prom metrics locally from one of the app instances
