### PR TITLE
User chpst when daemonize is false

### DIFF
--- a/definitions/puma_config.rb
+++ b/definitions/puma_config.rb
@@ -84,7 +84,7 @@ define :puma_config, :owner => 'deploy', :group => 'nginx', :directory  => nil, 
 
   service params[:name] do
     supports :start => true, :stop => true, :restart => true
-    action :nothing
+    action :start
   end
 
   template "#{params[:name]}" do
@@ -95,7 +95,7 @@ define :puma_config, :owner => 'deploy', :group => 'nginx', :directory  => nil, 
     owner params[:owner] if params[:owner]
     group params[:group] if params[:group]
     variables params
-    notifies :restart, "service[#{params[:name]}]", :delayed
+    notifies :start, "service[#{params[:name]}]", :delayed
   end
 
   if params[:logrotate]

--- a/definitions/puma_config.rb
+++ b/definitions/puma_config.rb
@@ -95,7 +95,7 @@ define :puma_config, :owner => 'deploy', :group => 'nginx', :directory  => nil, 
     owner params[:owner] if params[:owner]
     group params[:group] if params[:group]
     variables params
-    notifies :restart, "service[#{params[:name]}]", :delayed
+    notifies :start, "service[#{params[:name]}]", :delayed
   end
 
   if params[:logrotate]

--- a/definitions/puma_config.rb
+++ b/definitions/puma_config.rb
@@ -84,7 +84,7 @@ define :puma_config, :owner => 'deploy', :group => 'nginx', :directory  => nil, 
 
   service params[:name] do
     supports :start => true, :stop => true, :restart => true
-    action :nothing
+    action :enable
   end
 
   template "#{params[:name]}" do

--- a/definitions/puma_config.rb
+++ b/definitions/puma_config.rb
@@ -84,7 +84,7 @@ define :puma_config, :owner => 'deploy', :group => 'nginx', :directory  => nil, 
 
   service params[:name] do
     supports :start => true, :stop => true, :restart => true
-    action :enable
+    action :nothing
   end
 
   template "#{params[:name]}" do

--- a/definitions/puma_config.rb
+++ b/definitions/puma_config.rb
@@ -95,7 +95,7 @@ define :puma_config, :owner => 'deploy', :group => 'nginx', :directory  => nil, 
     owner params[:owner] if params[:owner]
     group params[:group] if params[:group]
     variables params
-    notifies :start, "service[#{params[:name]}]", :delayed
+    notifies :restart, "service[#{params[:name]}]", :delayed
   end
 
   if params[:logrotate]

--- a/definitions/puma_config.rb
+++ b/definitions/puma_config.rb
@@ -84,7 +84,7 @@ define :puma_config, :owner => 'deploy', :group => 'nginx', :directory  => nil, 
 
   service params[:name] do
     supports :start => true, :stop => true, :restart => true
-    action :restart
+    action :nothing
   end
 
   template "#{params[:name]}" do

--- a/definitions/puma_config.rb
+++ b/definitions/puma_config.rb
@@ -84,7 +84,7 @@ define :puma_config, :owner => 'deploy', :group => 'nginx', :directory  => nil, 
 
   service params[:name] do
     supports :start => true, :stop => true, :restart => true
-    action :start
+    action :nothing
   end
 
   template "#{params[:name]}" do
@@ -95,6 +95,7 @@ define :puma_config, :owner => 'deploy', :group => 'nginx', :directory  => nil, 
     owner params[:owner] if params[:owner]
     group params[:group] if params[:group]
     variables params
+    notifies :enable, "service[#{params[:name]}]", :delayed
     notifies :start, "service[#{params[:name]}]", :delayed
   end
 

--- a/definitions/puma_config.rb
+++ b/definitions/puma_config.rb
@@ -84,7 +84,7 @@ define :puma_config, :owner => 'deploy', :group => 'nginx', :directory  => nil, 
 
   service params[:name] do
     supports :start => true, :stop => true, :restart => true
-    action :nothing
+    action :restart
   end
 
   template "#{params[:name]}" do
@@ -95,7 +95,7 @@ define :puma_config, :owner => 'deploy', :group => 'nginx', :directory  => nil, 
     owner params[:owner] if params[:owner]
     group params[:group] if params[:group]
     variables params
-    notifies :start, "service[#{params[:name]}]", :delayed
+    notifies :restart, "service[#{params[:name]}]", :delayed
   end
 
   if params[:logrotate]

--- a/templates/default/init.d.sh.erb
+++ b/templates/default/init.d.sh.erb
@@ -18,10 +18,10 @@ STOP="$PUMA_DIR/puma_stop.sh"
 RESTART="$PUMA_DIR/puma_restart.sh"
 
 start() {
-  <% if @daemonize %>
-  daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
-  <% else %>
+  <% if !@daemonize %>
   /sbin/runuser -u $USERNAME $START
+  <% else %>
+  daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
   <% end %>
 }
 

--- a/templates/default/init.d.sh.erb
+++ b/templates/default/init.d.sh.erb
@@ -18,11 +18,7 @@ STOP="$PUMA_DIR/puma_stop.sh"
 RESTART="$PUMA_DIR/puma_restart.sh"
 
 start() {
-  <% if @daemonize %>
   daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
-  <% else %>
-  /sbin/runuser -u $USERNAME $START
-  <% end %>
 }
 
 stop() {

--- a/templates/default/init.d.sh.erb
+++ b/templates/default/init.d.sh.erb
@@ -18,11 +18,7 @@ STOP="$PUMA_DIR/puma_stop.sh"
 RESTART="$PUMA_DIR/puma_restart.sh"
 
 start() {
-  <% if @daemonize %>
-  daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
-  <% else %>
   /sbin/runuser -u $USERNAME $START
-  <% end %>
 }
 
 stop() {

--- a/templates/default/init.d.sh.erb
+++ b/templates/default/init.d.sh.erb
@@ -21,7 +21,7 @@ start() {
   <% if @daemonize %>
   daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
   <% else %>
-  sudo -u $USERNAME $START
+  /sbin/runuser -u $USERNAME $START
   <% end %>
 }
 

--- a/templates/default/init.d.sh.erb
+++ b/templates/default/init.d.sh.erb
@@ -21,7 +21,7 @@ start() {
   <% if @daemonize %>
   daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
   <% else %>
-  chpst -u $USERNAME $START
+  /sbin/runuser -u $USERNAME $START
   <% end %>
 }
 

--- a/templates/default/init.d.sh.erb
+++ b/templates/default/init.d.sh.erb
@@ -21,7 +21,7 @@ start() {
   <% if @daemonize %>
   daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
   <% else %>
-  /sbin/runuser -u $USERNAME $START
+  sudo -u $USERNAME $START
   <% end %>
 }
 

--- a/templates/default/init.d.sh.erb
+++ b/templates/default/init.d.sh.erb
@@ -18,6 +18,7 @@ STOP="$PUMA_DIR/puma_stop.sh"
 RESTART="$PUMA_DIR/puma_restart.sh"
 
 start() {
+  <% if @daemonize %>
   daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
   <% else %>
   /sbin/runuser -u $USERNAME $START

--- a/templates/default/init.d.sh.erb
+++ b/templates/default/init.d.sh.erb
@@ -18,7 +18,11 @@ STOP="$PUMA_DIR/puma_stop.sh"
 RESTART="$PUMA_DIR/puma_restart.sh"
 
 start() {
+  <% if @daemonize %>
+  daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
+  <% else %>
   /sbin/runuser -u $USERNAME $START
+  <% end %>
 }
 
 stop() {

--- a/templates/default/init.d.sh.erb
+++ b/templates/default/init.d.sh.erb
@@ -18,7 +18,11 @@ STOP="$PUMA_DIR/puma_stop.sh"
 RESTART="$PUMA_DIR/puma_restart.sh"
 
 start() {
+  <% if @daemonize %>
   daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
+  <% else %>
+  chpst -u $USERNAME $START
+  <% end %>
 }
 
 stop() {

--- a/templates/default/init.d.sh.erb
+++ b/templates/default/init.d.sh.erb
@@ -19,6 +19,9 @@ RESTART="$PUMA_DIR/puma_restart.sh"
 
 start() {
   daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
+  <% else %>
+  /sbin/runuser -u $USERNAME $START
+  <% end %>
 }
 
 stop() {

--- a/templates/default/puma_start.sh.erb
+++ b/templates/default/puma_start.sh.erb
@@ -6,5 +6,4 @@ PATH=/usr/local/bin:$PATH
 APPNAME="<%= @name %>"
 
 echo -n "Starting $APPNAME.."
-<% if !@daemonize; @exec_prefix = "exec #{@exec_prefix}" end %>
-<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %>&<% end %>
+<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %>

--- a/templates/default/puma_start.sh.erb
+++ b/templates/default/puma_start.sh.erb
@@ -6,5 +6,4 @@ PATH=/usr/local/bin:$PATH
 APPNAME="<%= @name %>"
 
 echo -n "Starting $APPNAME.."
-<% if !@daemonize; @exec_prefix = "exec #{@exec_prefix}" end %>
 <%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %>&<% end %>

--- a/templates/default/puma_start.sh.erb
+++ b/templates/default/puma_start.sh.erb
@@ -7,4 +7,4 @@ APPNAME="<%= @name %>"
 
 echo -n "Starting $APPNAME.."
 <% if !@daemonize; @exec_prefix = "exec #{@exec_prefix}" end %>
-cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %>
+cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %>&<% end %>

--- a/templates/default/puma_start.sh.erb
+++ b/templates/default/puma_start.sh.erb
@@ -6,4 +6,5 @@ PATH=/usr/local/bin:$PATH
 APPNAME="<%= @name %>"
 
 echo -n "Starting $APPNAME.."
+<% if !@daemonize; @exec_prefix = "exec #{@exec_prefix}" end %>
 <%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %>&<% end %>

--- a/templates/default/puma_start.sh.erb
+++ b/templates/default/puma_start.sh.erb
@@ -6,4 +6,5 @@ PATH=/usr/local/bin:$PATH
 APPNAME="<%= @name %>"
 
 echo -n "Starting $APPNAME.."
-<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %>
+<% if !@daemonize; @exec_prefix = "exec #{@exec_prefix}" end %>
+<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %>&<% end %>

--- a/templates/default/puma_start.sh.erb
+++ b/templates/default/puma_start.sh.erb
@@ -7,4 +7,4 @@ APPNAME="<%= @name %>"
 
 echo -n "Starting $APPNAME.."
 <% if !@daemonize; @exec_prefix = "exec #{@exec_prefix}" end %>
-cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %>&<% end %>
+<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %>&<% end %>

--- a/templates/default/puma_start.sh.erb
+++ b/templates/default/puma_start.sh.erb
@@ -7,4 +7,4 @@ APPNAME="<%= @name %>"
 
 echo -n "Starting $APPNAME.."
 <% if !@daemonize; @exec_prefix = "exec #{@exec_prefix}" end %>
-<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %>&<% end %>
+cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %>


### PR DESCRIPTION
What
----------------------
Use a different command depending on `@daemonize` flag.
* `daemon` when `true`
* `sudo -u root ./puma_start.sh` when `false`

Why
----------------------
user-service cookbook has daemonize flag off hence the servers are not live in the haproxy. The fix is to add an if condition.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
https://sportngin.atlassian.net/browse/IS-11823

QA Plan
-------
- [ ] run `ssh clone-instance staging -d` and chose any app server to clone from. Wait until the server is ready and check if it is alive: http://54.84.236.139/haproxy?stats
