### PR TITLE
Revert #15

### DIFF
--- a/definitions/puma_config.rb
+++ b/definitions/puma_config.rb
@@ -4,7 +4,7 @@ define :puma_config, :owner => 'deploy', :group => 'nginx', :directory  => nil, 
                      :quiet => false, :thread_min => 0, :thread_max => 16, :bind => nil, :control_app_bind => nil,
                      :workers => 0, :activate_control_app => true, :logrotate => true, :exec_prefix => nil,
                      :config_source => nil, :config_cookbook => nil, :worker_timeout => nil,
-                     :preload_app => false, :prune_bundler => true, :on_worker_boot => nil, :plugins => nil do
+                     :preload_app => false, :prune_bundler => true, :on_worker_boot => nil do
 
   params[:directory] ||= "/srv/www/#{params[:name]}"
   params[:working_dir] ||= "#{params[:directory]}/current"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,8 +20,6 @@ node[:deploy].each do |application, deploy|
     restart_timeout deploy[:puma][:restart_timeout] || 120
     exec_prefix deploy[:puma][:exec_prefix] || "bundle exec"
     prune_bundler deploy[:puma][:prune_bundler]
-    plugins deploy[:puma][:plugins]
-    daemonize deploy[:puma][:daemonize]
   end
 end
 

--- a/templates/default/init.d.sh.erb
+++ b/templates/default/init.d.sh.erb
@@ -18,10 +18,10 @@ STOP="$PUMA_DIR/puma_stop.sh"
 RESTART="$PUMA_DIR/puma_restart.sh"
 
 start() {
-  <% if @daemonize %>
-  daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
-  <% else %>
+  <% if !@daemonize %>
   /sbin/runuser -u $USERNAME $START
+  <% else %>
+  daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
   <% end %>
 }
 

--- a/templates/default/init.d.sh.erb
+++ b/templates/default/init.d.sh.erb
@@ -18,7 +18,11 @@ STOP="$PUMA_DIR/puma_stop.sh"
 RESTART="$PUMA_DIR/puma_restart.sh"
 
 start() {
+  <% if !@daemonize %>
+  /sbin/runuser -u $USERNAME $START
+  <% else %>
   daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
+  <% end %>
 }
 
 stop() {

--- a/templates/default/init.d.sh.erb
+++ b/templates/default/init.d.sh.erb
@@ -18,11 +18,7 @@ STOP="$PUMA_DIR/puma_stop.sh"
 RESTART="$PUMA_DIR/puma_restart.sh"
 
 start() {
-  <% if !@daemonize %>
-  /sbin/runuser -u $USERNAME $START
-  <% else %>
   daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
-  <% end %>
 }
 
 stop() {

--- a/templates/default/init.d.sh.erb
+++ b/templates/default/init.d.sh.erb
@@ -18,7 +18,11 @@ STOP="$PUMA_DIR/puma_stop.sh"
 RESTART="$PUMA_DIR/puma_restart.sh"
 
 start() {
+  <% if @daemonize %>
   daemon --user $USERNAME --pidfile $PIDFILE $START && success || failure
+  <% else %>
+  /sbin/runuser -u $USERNAME $START
+  <% end %>
 }
 
 stop() {

--- a/templates/default/puma.rb.erb
+++ b/templates/default/puma.rb.erb
@@ -3,13 +3,6 @@
 # The directory to operate out of.
 directory "<%= @working_dir %>"
 
-# A list of plugins for puma to load in
-<% if @plugins %>
-  <% @plugins.each do |plugin| %>
-plugin '<%= plugin %>'
-  <% end %>
-<% end %>
-
 # Use a object or block as the rack application. This allows the
 # config file to be the application itself.
 #

--- a/templates/default/puma_start.sh.erb
+++ b/templates/default/puma_start.sh.erb
@@ -6,4 +6,4 @@ PATH=/usr/local/bin:$PATH
 APPNAME="<%= @name %>"
 
 echo -n "Starting $APPNAME.."
-<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %>
+<%= @init_command %>cd <%= @working_dir %> && exec <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %>&<% end %>

--- a/templates/default/puma_start.sh.erb
+++ b/templates/default/puma_start.sh.erb
@@ -6,5 +6,4 @@ PATH=/usr/local/bin:$PATH
 APPNAME="<%= @name %>"
 
 echo -n "Starting $APPNAME.."
-<% if !@daemonize; @exec_prefix = "exec #{@exec_prefix}" end %>
-<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %>&<% end %>
+<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %>

--- a/templates/default/puma_start.sh.erb
+++ b/templates/default/puma_start.sh.erb
@@ -6,5 +6,4 @@ PATH=/usr/local/bin:$PATH
 APPNAME="<%= @name %>"
 
 echo -n "Starting $APPNAME.."
-<% if !@daemonize; @exec_prefix = "exec #{@exec_prefix}" end %>
 <%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %>&<% end %>

--- a/templates/default/puma_start.sh.erb
+++ b/templates/default/puma_start.sh.erb
@@ -6,4 +6,4 @@ PATH=/usr/local/bin:$PATH
 APPNAME="<%= @name %>"
 
 echo -n "Starting $APPNAME.."
-<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %>&<% end %>
+<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %>

--- a/templates/default/puma_start.sh.erb
+++ b/templates/default/puma_start.sh.erb
@@ -6,4 +6,5 @@ PATH=/usr/local/bin:$PATH
 APPNAME="<%= @name %>"
 
 echo -n "Starting $APPNAME.."
-<%= @init_command %>cd <%= @working_dir %> && exec <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %>&<% end %>
+<% if !@daemonize; @exec_prefix = "exec #{@exec_prefix}" end %>
+<%= @init_command %>cd <%= @working_dir %> && <%= @exec_prefix %> <%= @bin_path %> -C <%= @config_path %> <% if !@daemonize %>&<% end %>


### PR DESCRIPTION
What
----------------------
puma service fails to start automatically. We revert this PR: https://github.com/sportngin-cookbooks/opsworks-puma/pull/15/files which had daemonize flag set. 

Why
----------------------
to fix the auto start of puma service

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
https://sportngin.atlassian.net/browse/IS-11823

QA Plan
-------
- [x] QA https://github.com/sportngin/user-service-cookbook/pull/44
